### PR TITLE
impr: use enum definitions to explain options in usage

### DIFF
--- a/Sources/XcbeautifyLib/Constants.swift
+++ b/Sources/XcbeautifyLib/Constants.swift
@@ -41,8 +41,20 @@ package enum OutputType {
     case issue
 }
 
+public protocol UsageOptionsDescribable {
+    static var optionsDescription: String { get }
+}
+
+public extension
+UsageOptionsDescribable where Self: CaseIterable, Self: RawRepresentable, Self.RawValue: StringProtocol {
+    static var optionsDescription: String {
+        allCases.map(\.rawValue).joined(separator: " | ")
+    }
+}
+
 /// Maps to an `OutputRendering` type that formats raw `xcodebuild` output.
-public enum Renderer: String {
+public enum Renderer: String, CaseIterable, UsageOptionsDescribable {
+    
     /// The default `OutputRendering` type for local and general use. Maps to `TerminalRenderer`.
     case terminal
 

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -9,8 +9,9 @@ struct Xcbeautify: ParsableCommand {
         discussion: "EXAMPLE: xcodebuild test ... | xcbeautify",
         version: version
     )
-
-    enum Report: String, ExpressibleByArgument {
+    
+    enum Report: String, ExpressibleByArgument, CaseIterable, UsageOptionsDescribable {
+        
         case junit
     }
 
@@ -34,7 +35,7 @@ struct Xcbeautify: ParsableCommand {
 
     // swiftformat:disable redundantReturn
 
-    @Option(help: "Specify a renderer to format raw xcodebuild output ( options: terminal | github-actions | teamcity | azure-devops-pipelines).")
+    @Option(help: "Specify a renderer to format raw xcodebuild output. (Options: \(Renderer.optionsDescription)). (Default: terminal).")
     var renderer: Renderer = {
         if ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true" {
             return .gitHubActions
@@ -49,7 +50,7 @@ struct Xcbeautify: ParsableCommand {
 
     // swiftformat:enable redundantReturn
 
-    @Option(help: "Generate the specified reports")
+    @Option(help: "Generate the specified reports. (Options: \(Report.optionsDescription) (Default: none).")
     var report: [Report] = []
 
     @Option(help: "The path to use when generating reports")


### PR DESCRIPTION
It's not yet available via an official release of ArgumentParser, but a new property `allValueDescriptions` was added to `ExpressibleByArgument` so that it automatically prints the enum options and default where possible:

```
❯ swift run xcbeautify -h
Building for debugging...
[7/7] Applying xcbeautify
Build of product 'xcbeautify' complete! (1.10s)
OVERVIEW: A tool to format `swift` and `xcodebuild` command output.

EXAMPLE: xcodebuild test ... | xcbeautify

USAGE: xcbeautify [--quiet] [--quieter] [--preserve-unbeautified] [--is-ci] [--disable-colored-output] [--disable-logging] [--renderer <renderer>] [--report <report> ...] [--report-path <report-path>] [--junit-report-filename <junit-report-filename>]

OPTIONS:
  -q, --quiet             Only print tasks that have warnings or errors.
  --quieter, -qq          Only print tasks that have errors.
  --preserve-unbeautified Preserves unbeautified output lines.
  --is-ci                 Print test result too under quiet/quieter flag.
  --disable-colored-output
                          Disable the colored output
  --disable-logging       Suppress the xcbeautify information table when xcbeautify starts. It includes the active xcbeautify version.
  --renderer <renderer>   Specify a renderer to format raw xcodebuild output. (values: terminal, github-actions, teamcity, azure-devops-pipelines; default:
                          terminal)
  --report <report>       Generate the specified reports. (values: junit)
  --report-path <report-path>
                          The path to use when generating reports (default: build/reports)
  --junit-report-filename <junit-report-filename>
                          The name of JUnit report file name (default: junit.xml)
  --version               Show the version.
  -h, --help              Show help information.
```

In particular: 

>   --renderer <renderer>   Specify a renderer to format raw xcodebuild output. **(values: terminal, github-actions, teamcity, azure-devops-pipelines; default:
                          terminal)**

and 

>   --report <report>       Generate the specified reports. **(values: junit)**

Emphasizing the automatic output.

