### PR TITLE
impr: uptake of new ArgumentParser ExpressibleByArgument.allValueDescriptions feature

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
-        "version" : "1.5.0"
+        "branch" : "main",
+        "revision" : "10d80282e5fb5ae41338b54aeee5c9c5efc102ce"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-argument-parser.git",
-            .upToNextMinor(from: "1.5.0")
+            branch: "main"
         ),
         .package(
             url: "https://github.com/getGuaka/Colorizer.git",

--- a/Sources/XcbeautifyLib/Constants.swift
+++ b/Sources/XcbeautifyLib/Constants.swift
@@ -43,7 +43,6 @@ package enum OutputType {
 
 /// Maps to an `OutputRendering` type that formats raw `xcodebuild` output.
 public enum Renderer: String, CaseIterable {
-    
     /// The default `OutputRendering` type for local and general use. Maps to `TerminalRenderer`.
     case terminal
 

--- a/Sources/XcbeautifyLib/Constants.swift
+++ b/Sources/XcbeautifyLib/Constants.swift
@@ -41,19 +41,8 @@ package enum OutputType {
     case issue
 }
 
-public protocol UsageOptionsDescribable {
-    static var optionsDescription: String { get }
-}
-
-public extension
-UsageOptionsDescribable where Self: CaseIterable, Self: RawRepresentable, Self.RawValue: StringProtocol {
-    static var optionsDescription: String {
-        allCases.map(\.rawValue).joined(separator: " | ")
-    }
-}
-
 /// Maps to an `OutputRendering` type that formats raw `xcodebuild` output.
-public enum Renderer: String, CaseIterable, UsageOptionsDescribable {
+public enum Renderer: String, CaseIterable {
     
     /// The default `OutputRendering` type for local and general use. Maps to `TerminalRenderer`.
     case terminal

--- a/Sources/xcbeautify/OutputFormat+ExpressibleByArgument.swift
+++ b/Sources/xcbeautify/OutputFormat+ExpressibleByArgument.swift
@@ -5,4 +5,17 @@ import ArgumentParser
 #endif
 import XcbeautifyLib
 
-extension XcbeautifyLib.Renderer: ExpressibleByArgument { }
+extension XcbeautifyLib.Renderer: ExpressibleByArgument {
+    var defaultValueDescription: String {
+        switch self {
+        case .terminal:
+            "Local"
+        case .gitHubActions:
+            "GitHub actions (`GITHUB_ACTIONS` is defined as `true`)"
+        case .teamcity:
+            "TeamCity (`TEAMCITY_VERSION` is not `nil`)"
+        case .azureDevOpsPipelines:
+            "Azure DevOps Pipelines (`AZURE_DEVOPS_PIPELINES` is not `nil`)"
+        }
+    }
+}

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -9,9 +9,8 @@ struct Xcbeautify: ParsableCommand {
         discussion: "EXAMPLE: xcodebuild test ... | xcbeautify",
         version: version
     )
-    
+
     enum Report: String, ExpressibleByArgument, CaseIterable {
-        
         case junit
     }
 

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -10,7 +10,7 @@ struct Xcbeautify: ParsableCommand {
         version: version
     )
     
-    enum Report: String, ExpressibleByArgument, CaseIterable, UsageOptionsDescribable {
+    enum Report: String, ExpressibleByArgument, CaseIterable {
         
         case junit
     }
@@ -35,7 +35,7 @@ struct Xcbeautify: ParsableCommand {
 
     // swiftformat:disable redundantReturn
 
-    @Option(help: "Specify a renderer to format raw xcodebuild output. (Options: \(Renderer.optionsDescription)). (Default: terminal).")
+    @Option(help: "Specify a renderer to format raw xcodebuild output.")
     var renderer: Renderer = {
         if ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true" {
             return .gitHubActions
@@ -50,7 +50,7 @@ struct Xcbeautify: ParsableCommand {
 
     // swiftformat:enable redundantReturn
 
-    @Option(help: "Generate the specified reports. (Options: \(Report.optionsDescription) (Default: none).")
+    @Option(help: "Generate the specified reports.")
     var report: [Report] = []
 
     @Option(help: "The path to use when generating reports")


### PR DESCRIPTION
It's not yet available via an official release of ArgumentParser, but a new property `allValueDescriptions` was added to `ExpressibleByArgument` so that it automatically prints the enum options and default where possible. It also uses the already-available-in-latest-release `ExpressibleByArgument.defaultValueDescription` to explain the env-based Renderer defaults: 

```
❯ swift run xcbeautify -h
Building for debugging...
[7/7] Applying xcbeautify
Build of product 'xcbeautify' complete! (1.10s)
OVERVIEW: A tool to format `swift` and `xcodebuild` command output.

EXAMPLE: xcodebuild test ... | xcbeautify

USAGE: xcbeautify [--quiet] [--quieter] [--preserve-unbeautified] [--is-ci] [--disable-colored-output] [--disable-logging] [--renderer <renderer>] [--report <report> ...] [--report-path <report-path>] [--junit-report-filename <junit-report-filename>]

OPTIONS:
  -q, --quiet             Only print tasks that have warnings or errors.
  --quieter, -qq          Only print tasks that have errors.
  --preserve-unbeautified Preserves unbeautified output lines.
  --is-ci                 Print test result too under quiet/quieter flag.
  --disable-colored-output
                          Disable the colored output
  --disable-logging       Suppress the xcbeautify information table when xcbeautify starts. It includes the active xcbeautify version.
  --renderer <renderer>   Specify a renderer to format raw xcodebuild output. (default: terminal)
        terminal          - Local
        github-actions    - GitHub actions (`GITHUB_ACTIONS` is defined as `true`)
        teamcity          - TeamCity (`TEAMCITY_VERSION` is not `nil`)
        azure-devops-pipelines
                          - Azure DevOps Pipelines (`AZURE_DEVOPS_PIPELINES` is not `nil`)
  --report <report>       Generate the specified reports. (values: junit)
  --report-path <report-path>
                          The path to use when generating reports (default: build/reports)
  --junit-report-filename <junit-report-filename>
                          The name of JUnit report file name (default: junit.xml)
  --version               Show the version.
  -h, --help              Show help information.
```

In particular: 

>     --renderer <renderer>   Specify a renderer to format raw xcodebuild output. **(default: terminal)**

and 

>   --report <report>       Generate the specified reports. **(values: junit)**

Emphasizing the automatic output.

